### PR TITLE
Error corrected and information added

### DIFF
--- a/src/guide/files.md
+++ b/src/guide/files.md
@@ -93,8 +93,8 @@ By default local manga does not have any details. You can input the details by c
 ```
 {
   "title": "An Interesting Manga",
-  "author: ["Author 1", "Author 2"],
-  "genre: ": ["Romance", "Action"],
+  "author": ["Author 1", "Author 2"],
+  "genre": ["Romance", "Action"],
   "status": "Ongoing",
   "description": "This manga is so interesting",
   "cover_path": "relative/path/from/series/folder/to/thumbail.jpg",

--- a/src/guide/tracking.md
+++ b/src/guide/tracking.md
@@ -2,7 +2,7 @@
 
 Tanoshi can automatically update read manga chapters to supported trackers, namely [MyAnimeList](https://myanimelist.net/) and [AniList](https://anilist.co/).
 
-To be able to use tracking, you need to setup application on your tracker account and get `client_id` and `client_secret`, then put those value on your `config.yaml`
+To be able to use tracking, you need to setup application on your tracker account and get `client_id` and `client_secret`, then put those value on your `config.yaml`. You also need to have configured the base url in the `config.yaml`
 
 ```yaml
 myanimelist:


### PR DESCRIPTION
Fixed an error in the quotation marks for the example of details.json.
Added information about the need for the base URL to be configured for the tracker to work.